### PR TITLE
Shortcut execution in checkPermissions

### DIFF
--- a/src/ngUserAuthInfoService.factory.js
+++ b/src/ngUserAuthInfoService.factory.js
@@ -134,24 +134,12 @@
     }
 
     function checkPermissions(checkHasPermission, checkHasAnyPermission, checkLacksPermission) {
-      var checkOk = true;
-
       // hide if user does not have all required permissions
-      if (!hasPermission(checkHasPermission)) {
-        checkOk = false;
-      }
-
-      // hide if user does not have at least one of the permissions
-      if (!hasAnyPermission(checkHasAnyPermission)) {
-        checkOk = false;
-      }
-
-      // hide if user does have some of the forbidden permissions
-      if (!lacksPermission(checkLacksPermission)) {
-        checkOk = false;
-      }
-
-      return checkOk;
+      return hasPermission(checkHasPermission) &&
+        // hide if user does not have at least one of the permissions
+        hasAnyPermission(checkHasAnyPermission) &&
+        // hide if user does have some of the forbidden permissions
+        lacksPermission(checkLacksPermission);
     }
   }
 })();


### PR DESCRIPTION
This function shows up a lot in our navigation, with this change, we return early if one of the permission checks returns false, reducing the run time according to the Angular Bataranga profiler to 30ms (down from 50ms).